### PR TITLE
Add integration tests for slurmdbd operator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,16 @@
 # Copyright 2023 Canonical Ltd.
-# Apache Software License, version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 name: slurmdbd charm tests
 on:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Apache Software License, version 2.0
+
 name: slurmdbd charm tests
 on:
   workflow_call:
@@ -37,4 +40,23 @@ jobs:
       - name: Run tests
         run: tox -e unit
 
-# TODO: Add integration tests once they have been decided upon.
+  integration-test:
+    name: Integration tests (LXD)
+    runs-on: ubuntu-latest
+    needs:
+      - inclusive-naming-check
+      - lint
+      - unit-test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: python3 -m pip install tox
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: lxd
+          # Juju channel should eventually be updated to 3.0/stable
+          juju-channel: 2.9/stable
+      - name: Run tests
+        run: tox -e integration

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -187,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2023 Omnivector, LLC
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,16 @@
 # Copyright 2023 Canonical Ltd.
-# See LICENSE file for licensing details.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # Testing tools configuration
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,11 @@ show_missing = true
 minversion = "6.0"
 log_cli_level = "INFO"
 
+# Spell checking tools configuration
+[tool.codespell]
+skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.vscode,.coverage"
+
+
 # Formatting tools configuration
 [tool.black]
 line-length = 99

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,6 +1,17 @@
 #!/usr/bin/env python3
 # Copyright 2023 Canonical Ltd.
-# Apache Software License, version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Configure integration test run."""
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# Apache Software License, version 2.0
+
+"""Configure integration test run."""
+
+import pathlib
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from helpers import ETCD, VERSION
+
+
+@pytest.fixture(scope="module")
+async def slurmdbd_charm(ops_test: OpsTest):
+    """Build slurmdbd charm to use for integration tests."""
+    charm = await ops_test.build_charm(".")
+    return charm
+
+
+def pytest_sessionfinish(session, exitstatus) -> None:
+    """Clean up repository after test session has completed."""
+    pathlib.Path(ETCD).unlink(missing_ok=True)
+    pathlib.Path(VERSION).unlink(missing_ok=True)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# Apache Software License, version 2.0
+
+"""Helpers for the slurmdbd integration tests."""
+
+import contextlib
+import logging
+import pathlib
+import shlex
+import subprocess
+import tempfile
+from io import StringIO
+from typing import Dict
+
+import paramiko
+import tenacity
+from pytest_operator.plugin import OpsTest
+from urllib import request
+
+logger = logging.getLogger(__name__)
+
+ETCD = "etcd-v3.5.0-linux-amd64.tar.gz"
+ETCD_URL = f"https://github.com/etcd-io/etcd/releases/download/v3.5.0/{ETCD}"
+VERSION = "version"
+VERSION_NUM = subprocess.run(
+    shlex.split("git describe --always"), stdout=subprocess.PIPE, text=True
+).stdout.strip("\n")
+
+
+def get_slurmctld_res() -> Dict[str, pathlib.Path]:
+    """Get slurmctld resources needed for charm deployment."""
+    if not (etcd := pathlib.Path(ETCD)).exists():
+        logger.info(f"Getting resource {ETCD} from {ETCD_URL}...")
+        request.urlretrieve(ETCD_URL, etcd)
+
+    return {"etcd": etcd}
+
+
+def get_slurmdbd_res() -> None:
+    """Get slurmdbd charm resources needed for deployment."""
+    if not (version := pathlib.Path(VERSION)).exists():
+        logger.info(f"Setting resource {VERSION} to value {VERSION_NUM}...")
+        version.write_text(VERSION_NUM)
+
+
+@contextlib.asynccontextmanager
+async def unit_connection(
+    ops_test: OpsTest, application: str, target_unit: str
+) -> paramiko.SSHClient:
+    """Asynchronous context manager for connecting to a Juju unit via SSH.
+
+    Args:
+        ops_test (OpsTest): Utility class for charmed operators.
+        application (str): Name of application target unit belongs to. e.g. slurmdbd
+        target_unit (str): Name of unit to connect to via ssh. e.g. slurmdbd/0
+
+    Yields:
+        (paramiko.SSHClient): Open SSH connection to target unit. Connection is
+            closed after context manager exits.
+
+    Notes:
+        Paramiko may fail to establish an ssh connection with the target Juju unit on
+        the first try, so tenacity is used to reattempt the connection for 60 seconds.
+        This to do with a delay in the public key being ready inside the unit.
+    """
+
+    @tenacity.retry(
+        wait=tenacity.wait.wait_exponential(multiplier=2, min=1, max=30),
+        stop=tenacity.stop_after_attempt(10),
+        reraise=True,
+    )
+    def _connect(ssh_client: paramiko.SSHClient, **kwargs) -> None:
+        """Establish SSH connection to Juju unit."""
+        ssh_client.connect(**kwargs)
+
+    with tempfile.TemporaryDirectory() as _:
+        logger.info("Setting up private/public ssh keypair...")
+        private_key_path = pathlib.Path(_).joinpath("id")
+        public_key_path = pathlib.Path(_).joinpath("id.pub")
+        subprocess.check_call(
+            shlex.split(
+                f"ssh-keygen -f {str(private_key_path)} -t rsa -N '' -q -C Juju:juju@localhost"
+            )
+        )
+        await ops_test.model.add_ssh_key("ubuntu", (pubkey := public_key_path.read_text()))
+        # Verify that public key is available in Juju model otherwise ssh connection may fail.
+        for response in (await ops_test.model.get_ssh_keys(raw_ssh=True))["results"]:
+            assert pubkey.strip("\n") in response["result"]
+        pkey = paramiko.RSAKey.from_private_key(StringIO(private_key_path.read_text()))
+
+    ssh = paramiko.SSHClient()
+    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    for unit in ops_test.model.applications[application].units:
+        if unit.name == target_unit:
+            logger.info(f"Opening ssh connection to unit {target_unit}...")
+            _connect(
+                ssh, hostname=str(await unit.get_public_address()), username="ubuntu", pkey=pkey
+            )
+    yield ssh
+    logger.info(f"Closing ssh connection to unit {target_unit}...")
+    ssh.close()

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,6 +1,17 @@
 #!/usr/bin/env python3
 # Copyright 2023 Canonical Ltd.
-# Apache Software License, version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Helpers for the slurmdbd integration tests."""
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -15,18 +15,12 @@
 
 """Helpers for the slurmdbd integration tests."""
 
-import contextlib
 import logging
 import pathlib
 import shlex
 import subprocess
-import tempfile
-from io import StringIO
 from typing import Dict
 
-import paramiko
-import tenacity
-from pytest_operator.plugin import OpsTest
 from urllib import request
 
 logger = logging.getLogger(__name__)
@@ -53,61 +47,3 @@ def get_slurmdbd_res() -> None:
     if not (version := pathlib.Path(VERSION)).exists():
         logger.info(f"Setting resource {VERSION} to value {VERSION_NUM}...")
         version.write_text(VERSION_NUM)
-
-
-@contextlib.asynccontextmanager
-async def unit_connection(
-    ops_test: OpsTest, application: str, target_unit: str
-) -> paramiko.SSHClient:
-    """Asynchronous context manager for connecting to a Juju unit via SSH.
-
-    Args:
-        ops_test (OpsTest): Utility class for charmed operators.
-        application (str): Name of application target unit belongs to. e.g. slurmdbd
-        target_unit (str): Name of unit to connect to via ssh. e.g. slurmdbd/0
-
-    Yields:
-        (paramiko.SSHClient): Open SSH connection to target unit. Connection is
-            closed after context manager exits.
-
-    Notes:
-        Paramiko may fail to establish an ssh connection with the target Juju unit on
-        the first try, so tenacity is used to reattempt the connection for 60 seconds.
-        This to do with a delay in the public key being ready inside the unit.
-    """
-
-    @tenacity.retry(
-        wait=tenacity.wait.wait_exponential(multiplier=2, min=1, max=30),
-        stop=tenacity.stop_after_attempt(10),
-        reraise=True,
-    )
-    def _connect(ssh_client: paramiko.SSHClient, **kwargs) -> None:
-        """Establish SSH connection to Juju unit."""
-        ssh_client.connect(**kwargs)
-
-    with tempfile.TemporaryDirectory() as _:
-        logger.info("Setting up private/public ssh keypair...")
-        private_key_path = pathlib.Path(_).joinpath("id")
-        public_key_path = pathlib.Path(_).joinpath("id.pub")
-        subprocess.check_call(
-            shlex.split(
-                f"ssh-keygen -f {str(private_key_path)} -t rsa -N '' -q -C Juju:juju@localhost"
-            )
-        )
-        await ops_test.model.add_ssh_key("ubuntu", (pubkey := public_key_path.read_text()))
-        # Verify that public key is available in Juju model otherwise ssh connection may fail.
-        for response in (await ops_test.model.get_ssh_keys(raw_ssh=True))["results"]:
-            assert pubkey.strip("\n") in response["result"]
-        pkey = paramiko.RSAKey.from_private_key(StringIO(private_key_path.read_text()))
-
-    ssh = paramiko.SSHClient()
-    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-    for unit in ops_test.model.applications[application].units:
-        if unit.name == target_unit:
-            logger.info(f"Opening ssh connection to unit {target_unit}...")
-            _connect(
-                ssh, hostname=str(await unit.get_public_address()), username="ubuntu", pkey=pkey
-            )
-    yield ssh
-    logger.info(f"Closing ssh connection to unit {target_unit}...")
-    ssh.close()

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,6 +1,17 @@
 #!/usr/bin/env python3
 # Copyright 2023 Canonical Ltd.
-# Apache Software License, version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Test slurmdbd charm against other SLURM charms in the latest/edge channel."""
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# Apache Software License, version 2.0
+
+"""Test slurmdbd charm against other SLURM charms in the latest/edge channel."""
+
+import codecs
+import logging
+import pathlib
+from typing import Any, Coroutine
+
+import asyncio
+import pytest
+import tenacity
+from pytest_operator.plugin import OpsTest
+
+from helpers import get_slurmctld_res, get_slurmdbd_res, unit_connection
+
+logger = logging.getLogger(__name__)
+
+SERIES = ["focal"]
+SLURMDBD = "slurmdbd"
+SLURMCTLD = "slurmctld"
+DATABASE = "percona-cluster"
+UNIT = f"{SLURMDBD}/0"
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.skip_if_deployed
+@pytest.mark.parametrize("series", SERIES)
+async def test_build_and_deploy_against_edge(
+    ops_test: OpsTest, slurmdbd_charm: Coroutine[Any, Any, pathlib.Path], series: str
+) -> None:
+    """Test that the slurmdbd charm can stabilize against slurmctld and percona."""
+    logger.info(f"Deploying {SLURMDBD} against {SLURMCTLD} and {DATABASE}...")
+    slurmctld_res = get_slurmctld_res()
+    get_slurmdbd_res()
+    await asyncio.gather(
+        ops_test.model.deploy(
+            str(await slurmdbd_charm),
+            application_name=SLURMDBD,
+            num_units=1,
+            series=series,
+        ),
+        ops_test.model.deploy(
+            SLURMCTLD,
+            application_name=SLURMCTLD,
+            channel="edge",
+            num_units=1,
+            resources=slurmctld_res,
+            series=series,
+        ),
+        ops_test.model.deploy(
+            DATABASE, application_name=DATABASE, channel="edge", num_units=1, series="bionic"
+        ),
+    )
+    # Attach resources to charms.
+    await ops_test.juju("attach-resource", SLURMCTLD, f"etcd={slurmctld_res['etcd']}")
+    # Set integrations for charmed applications.
+    await ops_test.model.relate(f"{SLURMDBD}:{SLURMDBD}", f"{SLURMCTLD}:{SLURMDBD}")
+    await ops_test.model.relate(f"{SLURMDBD}:db", f"{DATABASE}:db")
+    # Reduce the update status frequency to accelerate the triggering of deferred events.
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(apps=[SLURMDBD], status="active", timeout=1000)
+        assert ops_test.model.applications[SLURMDBD].units[0].workload_status == "active"
+
+
+@pytest.mark.abort_on_fail
+async def test_slurmdbd_is_active(ops_test: OpsTest) -> None:
+    """Test that slurmdbd is active inside Juju unit."""
+    logger.info("Checking that slurmdbd daemon is active inside unit...")
+    async with unit_connection(ops_test, SLURMDBD, UNIT) as conn:
+        stdin, stdout, stderr = conn.exec_command("systemctl is-active slurmdbd")
+        assert codecs.decode(stdout.read()).strip("\n") == "active"
+
+
+@pytest.mark.abort_on_fail
+@tenacity.retry(
+    wait=tenacity.wait.wait_exponential(multiplier=2, min=1, max=30),
+    stop=tenacity.stop_after_attempt(10),
+    reraise=True,
+)
+async def test_slurmdbd_port_listen(ops_test: OpsTest) -> None:
+    """Test that slurmdbd is listening on port 6819.
+
+    Notes:
+        This test may fail on the first attempt due to their being a delay between
+        netstat being installed and being available on the PATH, so tenacity is used
+        to reattempt the test.
+    """
+    logger.info("Checking that slurmdbd is listening on port 6819...")
+    async with unit_connection(ops_test, SLURMDBD, UNIT) as conn:
+        conn.exec_command("sudo apt-get -y install net-tools")
+        stdin, stdout, stderr = conn.exec_command("netstat -na | grep '0.0.0.0:6819'")
+        try:
+            assert "netstat: command not found" not in codecs.decode(stderr.read())
+        except AssertionError:
+            logger.error(f"netstat not found inside {UNIT}. Trying again...")
+        finally:
+            assert codecs.decode(stdout.read()).strip("\n").strip(" ")[-6:] == "LISTEN"
+
+
+@pytest.mark.abort_on_fail
+async def test_munge_is_active(ops_test: OpsTest) -> None:
+    """Test that slurmctld is active inside Juju unit."""
+    logger.info("Checking that munge is active inside Juju unit...")
+    async with unit_connection(ops_test, SLURMDBD, UNIT) as conn:
+        stdin, stdout, stderr = conn.exec_command("systemctl is-active munge")
+        assert codecs.decode(stdout.read()).strip("\n") == "active"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,4 +1,17 @@
 #!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Test default charm events such as upgrade charm, install, etc."""
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,8 +27,8 @@ deps =
     black
     ruff
 commands =
-    ruff --fix {[vars]all_path}
     black {[vars]all_path}
+    ruff --fix {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards

--- a/tox.ini
+++ b/tox.ini
@@ -55,3 +55,22 @@ commands =
         --source={[vars]src_path} \
         -m pytest -v --tb native -s {posargs} {[vars]tst_path}unit
     coverage report
+
+[testenv:integration]
+description = Run integration tests
+deps =
+    -r{toxinidir}/requirements.txt
+    juju==3.0.4
+    paramiko==2.12.0
+    pytest==7.2.0
+    pytest_operator==0.23.0
+    tenacity==8.1.0
+commands =
+    pytest -v \
+           -s \
+           --tb native \
+           --ignore={[vars]tst_path}unit \
+           --log-cli-level=INFO \
+           --model dev \
+           --keep-models \
+           {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -37,10 +37,7 @@ deps =
     ruff
     codespell
 commands =
-    codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
-        --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
-        --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
-
+    codespell {toxinidir}
     ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,9 +17,9 @@ setenv =
     PYTHONBREAKPOINT=pdb.set_trace
     PY_COLORS=1
 passenv =
-  PYTHONPATH
-  CHARM_BUILD_DIR
-  MODEL_SETTINGS
+    PYTHONPATH
+    CHARM_BUILD_DIR
+    MODEL_SETTINGS
 
 [testenv:fmt]
 description = Apply coding style standards to code
@@ -38,8 +38,8 @@ deps =
     codespell
 commands =
     codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
-      --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
-      --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
+        --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
+        --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
 
     ruff {[vars]all_path}
     black --check --diff {[vars]all_path}

--- a/tox.ini
+++ b/tox.ini
@@ -71,6 +71,6 @@ commands =
            --tb native \
            --ignore={[vars]tst_path}unit \
            --log-cli-level=INFO \
-           --model dev \
+           --model controller \
            --keep-models \
            {posargs}


### PR DESCRIPTION
## Description

This pull request adds integration tests for the slurmdbd operator. The tests first build and deploy slurmdbd against the other slurm charms from latest/edge, checks that the slurmdbd and munge daemons are up, and verifies that slurmdbd is listening on port 6819.

## How was the code tested?

I tested the code locally on my workstation

## Related issues and/or tasks

This pull request is a part of the Charmed SLURM project.

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [ ] All requested changes and/or review comments have been resolved.
